### PR TITLE
Automatic update of dependency thoth-common from 0.0.5 to 0.0.6

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2d88e3c5056f89e661bd7fe24137d1da0cdcb4da3f3155cb19676e1688beb92c"
+            "sha256": "88b1529478ea5de6275bf9914a35af721f6ccb67f5431e2f9458a700e8bd7a15"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -249,10 +249,11 @@
         },
         "thoth-common": {
             "hashes": [
-                "sha256:4225bb0acf03bf40dfa0b8440d530e17e4ea0e1063df9aa8f0015484720fe581",
-                "sha256:c0fdeb553bc7e64c830b9dabd894dd41adcf1807a0c571709750de3d23f909e3"
+                "sha256:729d00c4e253858c07b2088b4eaf6455467636b18f8241535fd374481d5d78e4",
+                "sha256:a069378ba69a2d9036a336baae000f52281bf514414bf5d6fd5902e2a6aa808b"
             ],
-            "version": "==0.0.5"
+            "index": "pypi",
+            "version": "==0.0.6"
         },
         "thoth-storages": {
             "hashes": [


### PR DESCRIPTION
Dependency thoth-common was used in version 0.0.5, but the current latest version is 0.0.6.