### PR TITLE
Automatic update of dependency thoth-storages from 0.0.25 to 0.0.28

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "88b1529478ea5de6275bf9914a35af721f6ccb67f5431e2f9458a700e8bd7a15"
+            "sha256": "922601a9d579dc31c8e1f8f7d579f4e2b421fac6480d291a976f2ba4f2b8fc01"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -257,10 +257,11 @@
         },
         "thoth-storages": {
             "hashes": [
-                "sha256:d412e6c2185c7ca1d678e18f66f817d4e2e110071b3ce54f740b99f913da5b24",
-                "sha256:919fd4d448c6b5a0cd7c6a34c43a55a488e12a80643ae442b3ded198d1b6ad94"
+                "sha256:44d154ba9fdfec6f4baa43dfaa6707a9893196f6c74d577dabedd53285bf4ff1",
+                "sha256:b2d2b82a975f6e011b368f087066804e4952840da424cbfac7fc49bed1e0b2ab"
             ],
-            "version": "==0.0.25"
+            "index": "pypi",
+            "version": "==0.0.28"
         },
         "tornado": {
             "hashes": [


### PR DESCRIPTION
Dependency thoth-storages was used in version 0.0.25, but the current latest version is 0.0.28.