### PR TITLE
renamed the templates

### DIFF
--- a/openshift/inspectionSyncJob-template.yaml
+++ b/openshift/inspectionSyncJob-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: graph-sync-job-inspection
+  name: graph-sync-inspection-cronjob
   annotations:
     description: "Thoth: Graph Sync Job for inspection documents"
     openshift.io/display-name: "Thoth: Graph Sync Job Solver"
@@ -12,7 +12,7 @@ metadata:
       This template defines resources needed to deploy Thoth's Graph Sync Job for Solvers on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: graph-sync-job-inspection
+    template: graph-sync-inspection-cronjob
     app: thoth
     component: graph-sync
 

--- a/openshift/packageExtractSyncJob-template.yaml
+++ b/openshift/packageExtractSyncJob-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: graph-sync-job-package-extract
+  name: graph-sync-package-extract-cronjob
   annotations:
     description: "Thoth: Graph Sync Job for package-extract documents"
     openshift.io/display-name: "Thoth: Graph Sync Job Solver"
@@ -12,7 +12,7 @@ metadata:
       This template defines resources needed to deploy Thoth's Graph Sync Job for Solvers on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: graph-sync-job-package-extract
+    template: graph-sync-package-extract-cronjob
     app: thoth
     component: graph-sync
 

--- a/openshift/solverSyncJob-template.yaml
+++ b/openshift/solverSyncJob-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: graph-sync-job-solver
+  name: graph-sync-solver-cronjob
   annotations:
     description: "Thoth: Graph Sync Job for solver documents"
     openshift.io/display-name: "Thoth: Graph Sync Job Solver"
@@ -12,7 +12,7 @@ metadata:
       This template defines resources needed to deploy Thoth's Graph Sync Job for Solvers on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: graph-sync-job-solver
+    template: graph-sync-solver-cronjob
     app: thoth
     component: graph-sync
 


### PR DESCRIPTION
as the ansible cronjob role expects the templates to be called ...-cronjob

TODO we need to rewrite the cronjob ansible module

Signed-off-by: Christoph Görn <goern@redhat.com>