### PR TITLE
Update zuul pipeline to use the new version trigger build job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -14,4 +14,6 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: "https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/graph-sync-job"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "graph-sync-job"

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -59,6 +59,10 @@ objects:
       triggers:
         - imageChange: {}
           type: ImageChange
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
 parameters:
   - description: Git repository for Thoth's Graph Sync Job


### PR DESCRIPTION
Add generic trigger to buildconfig for incoming generic webhook.
The generic-webhook-secret secret is a prerequisite for using this new build config.
Update the zuul config to use the new trigger build job API in zuul-config.