### PR TITLE
Increase backoff limit for syncs due to transactions

### DIFF
--- a/openshift/adviserSyncJob-template.yaml
+++ b/openshift/adviserSyncJob-template.yaml
@@ -56,6 +56,7 @@ objects:
         mark: cleanup
         ttl: "1h"
     spec:
+      backoffLimit: 10
       template:
         metadata:
           labels:

--- a/openshift/packageExtractSyncJob-template.yaml
+++ b/openshift/packageExtractSyncJob-template.yaml
@@ -58,6 +58,7 @@ objects:
         mark: cleanup
         ttl: "1h"
     spec:
+      backoffLimit: 10
       template:
         metadata:
           labels:

--- a/openshift/provenanceCheckerSyncJob-template.yaml
+++ b/openshift/provenanceCheckerSyncJob-template.yaml
@@ -56,6 +56,7 @@ objects:
         mark: cleanup
         ttl: "1h"
     spec:
+      backoffLimit: 10
       template:
         metadata:
           labels:

--- a/openshift/solverSyncJob-template.yaml
+++ b/openshift/solverSyncJob-template.yaml
@@ -58,6 +58,7 @@ objects:
         mark: cleanup
         ttl: "1h"
     spec:
+      backoffLimit: 10
       template:
         metadata:
           labels:


### PR DESCRIPTION
Some of the jobs failed because of number of retries due to transaction collisions. Let's increase backoff limit for these cases.