### PR TITLE
Hotfix for the var force_sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,7 +108,7 @@ def _do_sync(
     start_time = time.monotonic()
     stats = sync_documents(
         document_ids,
-        force_sync=force_sync,
+        force=force_sync,
         graceful=False,
         inspection_only_graph_sync=inspection_only_graph_sync,
         inspection_only_ceph_sync=inspection_only_ceph_sync,
@@ -119,10 +119,18 @@ def _do_sync(
     for category, category_stats in stats.items():
         processed, synced, skipped, failed = category_stats
         _METRIC_SECONDS.labels(category=category, namespace=namespace).set(sync_time)
-        _METRIC_RESULTS_PROCESSED.labels(category=category, namespace=namespace).inc(processed)
-        _METRIC_RESULTS_SYNCED.labels(category=category, namespace=namespace).inc(synced)
-        _METRIC_RESULTS_SKIPPED.labels(category=category, namespace=namespace).inc(skipped)
-        _METRIC_RESULTS_FAILED.labels(category=category, namespace=namespace).inc(failed)
+        _METRIC_RESULTS_PROCESSED.labels(category=category, namespace=namespace).inc(
+            processed
+        )
+        _METRIC_RESULTS_SYNCED.labels(category=category, namespace=namespace).inc(
+            synced
+        )
+        _METRIC_RESULTS_SKIPPED.labels(category=category, namespace=namespace).inc(
+            skipped
+        )
+        _METRIC_RESULTS_FAILED.labels(category=category, namespace=namespace).inc(
+            failed
+        )
 
 
 @click.command()

--- a/openshift/syncJob-template.yaml
+++ b/openshift/syncJob-template.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: graph-sync-job-mutliple
+  name: graph-sync-job
   annotations:
     description: "Thoth: Graph Sync Job for syncing multiple documents"
     openshift.io/display-name: "Thoth: Graph Sync Job Multiple Documents"
@@ -12,7 +12,7 @@ metadata:
       This template defines resources needed to deploy Thoth's Graph Sync Job on OpenShift.
     template.openshift.io/provider-display-name: Red Hat, Inc.
   labels:
-    template: graph-sync-job-multiple
+    template: graph-sync-job
     app: thoth
     component: graph-sync
     graph-sync-type: multiple


### PR DESCRIPTION
Hotfixed it for now.
- the variable force_sync is used as force in storages.
https://github.com/thoth-station/storages/blob/a7f7fcbee2fe2f29366a4b6f366ad8d4a6d46f4d/thoth/storages/sync.py#L384

- hotfix of the template name
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>