### PR TITLE
Template metadata label graph-sync-type is not required

### DIFF
--- a/openshift/syncJob-template.yaml
+++ b/openshift/syncJob-template.yaml
@@ -16,7 +16,6 @@ metadata:
     template: graph-sync-job
     app: thoth
     component: graph-sync
-    graph-sync-type: "${THOTH_GRAPH_SYNC_TYPE}"
 
 parameters:
   - description: Registry the ImageStream to be use lives in


### PR DESCRIPTION
Template metadata label graph-sync-type is not required
Fixes:
```
The Template "graph-sync-job" is invalid: metadata.labels: Invalid value: "${THOTH_GRAPH_SYNC_TYPE}": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>