### PR TITLE
Remove ttl configuration for cleanup

### DIFF
--- a/openshift/syncJob-template.yaml
+++ b/openshift/syncJob-template.yaml
@@ -102,7 +102,6 @@ objects:
         component: graph-sync
         graph-sync-type: "${THOTH_GRAPH_SYNC_TYPE}"
         mark: cleanup
-        ttl: "24h"
     spec:
       backoffLimit: 1
       template:
@@ -112,7 +111,6 @@ objects:
             component: graph-sync
             graph-sync-type: "${THOTH_GRAPH_SYNC_TYPE}"
             mark: cleanup
-            ttl: "24h"
         spec:
           containers:
             - name: graph-sync


### PR DESCRIPTION
Let's have one centralized point for conifguring this - cleanup job itself.

Related: https://github.com/thoth-station/cleanup-job/pull/215