### PR TITLE
Increase backoff limit for failing graph syncs

### DIFF
--- a/openshift/syncJob-template.yaml
+++ b/openshift/syncJob-template.yaml
@@ -103,7 +103,7 @@ objects:
         graph-sync-type: "${THOTH_GRAPH_SYNC_TYPE}"
         mark: cleanup
     spec:
-      backoffLimit: 1
+      backoffLimit: 7
       template:
         metadata:
           labels:


### PR DESCRIPTION
When running graph-sync-jobs in the cluster, there was an issue when
graph-syncs did not sync the document and retried just once. If the second
retry failed, they went to failed state and were deleted by OpenShift. Let's
increase backoff limit to retry syncs multiple times to get into a successful
state or to have reported issues.