### PR TITLE
updating pre-commit protocol and build-strategy

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,7 +2,7 @@ check:
   - thoth-build
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
-  build-stratergy: Source
+  build-strategy: Source
   registry: quay.io
   registry-org: thoth-station
   registry-project: graph-sync-job

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 ---
 repos:
-  - repo: git://github.com/asottile/add-trailing-comma
+  - repo: https://github.com/asottile/add-trailing-comma
     rev: v2.0.1
     hooks:
       - id: add-trailing-comma
 
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
       - id: trailing-whitespace
@@ -27,7 +27,7 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: "5.0.2"
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
Using unencrypted version of the git protocol has been deprecated. Switching to HTTPS for pre-commit repos.

Additionally changing `build-stratergy` to `build-strategy`. Changes have already been made to accommodate this.

## Related Issues and Dependencies

Related to: https://github.com/thoth-station/thoth-application/issues/2111
